### PR TITLE
Update Fig4_Fig5_Robustness.ipynb

### DIFF
--- a/Fig4_Fig5_Robustness.ipynb
+++ b/Fig4_Fig5_Robustness.ipynb
@@ -152,7 +152,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Shift the window back by 0.04s, and increase the width by a factor of 2. \n",
+    "### Shift the window back by 0.04s, and increase the width by a factor of 2. Due to the 20ms taken for sliding one detector, this tripples the size of the correlation window.\n",
     "\n",
     "This keeps the end of the window at the same time."
    ]
@@ -293,7 +293,7 @@
     "\n",
     "lines = pylab.gca().get_lines()\n",
     "leg1 = pylab.legend([lines[0], lines[1]], ['Original Data Including Signal', 'ML Waveform Subtracted Data'], loc=\"upper left\")\n",
-    "leg2 = pylab.legend([lines[0], lines[2], lines[4]], ['Window Size Doubled', 'Window Shifted', 'Bandwidth Narrowed'], loc=\"lower left\")\n",
+    "leg2 = pylab.legend([lines[0], lines[2], lines[4]], ['Window Size Increased', 'Window Shifted', 'Bandwidth Narrowed'], loc=\"lower left\")\n",
     "\n",
     "_, _, s, e = res.indices_within_window(corr1)\n",
     "pylab.axvspan(s*1000, e*1000, alpha=0.3, color='grey', zorder=-1)\n",


### PR DESCRIPTION
Clarify what changing the width option does here. Given the padding that is used to allow for the +- 10ms sliding of one detector, the correlation window is tripled. Make that explicit. 